### PR TITLE
Only offset zoom controls on mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -42,10 +42,6 @@ div.olControlZoom a {
 	filter: alpha(opacity=80);
 }
 
-.leaflet-control-zoom {
-	margin-top: 50px !important;
-}
-
 input#search {
 	width: 180px;
 	margin: 10px 10px;
@@ -151,6 +147,12 @@ table#trackingDevices {
 }
 #trackingDevices > thead > tr > th:first-child {
 	width: 150px;
+}
+
+@media only screen and (max-width: 768px) {
+	.leaflet-control-zoom {
+		margin-top: 50px;
+	}
 }
 
 /* css for timepicker */


### PR DESCRIPTION
Remove offset of the zoom controls on desktop while keeping it for small screens.

current master:
![image](https://cloud.githubusercontent.com/assets/1267827/9174170/954ed204-3f7e-11e5-9e13-c864576657e3.png)
fix:
![image](https://cloud.githubusercontent.com/assets/1267827/9174137/6de145b2-3f7e-11e5-9fca-62338f1955ea.png)
