### PR TITLE
let the user define a name for favorites

### DIFF
--- a/controller/favoritecontroller.php
+++ b/controller/favoritecontroller.php
@@ -76,9 +76,9 @@ class FavoriteController extends ApiController {
 	 * @param $lng float
 	 * @return JSONResponse
 	 */
-	public function addFavorite($lat, $lng){
+	public function addFavorite($lat, $lng, $name = null){
 		$favorite = new Favorite();
-		$favorite->setName("empty");
+		$favorite->setName($name);
 		$favorite->setTimestamp(time());
 		$favorite->setUserId($this->userId);
 		$favorite->setLat($lat);

--- a/js/script.js
+++ b/js/script.js
@@ -1186,11 +1186,30 @@ Array.prototype.unique = function() {
 		favArray : [],
 		add : function(){
 			var latlng = $(this).attr("data-latlng").split(",");
-			var formData = {
-				lat : latlng[0],
-				lng : latlng[1]
-			};
-			$.post(OC.generateUrl('/apps/maps/api/1.0/favorite/addToFavorites'), formData);
+			var popupDiv = document.getElementsByClassName('leaflet-popup-content')[0];
+			var popupText = popupDiv.innerHTML;
+			var splitIndex = popupText.indexOf('<br>');
+			popupDiv.innerHTML = popupText.substring(splitIndex);
+			var nameDiv = document.createElement('div');
+			var nameInput = document.createElement('input');
+			var orgTitle = popupText.substring(0, splitIndex);
+			nameInput.type = 'text';
+			nameInput.value = orgTitle;
+			var submit = document.createElement('button');
+			submit.className = 'icon-checkmark';
+			submit.onclick = function(){
+				popupDiv.removeChild(nameDiv);
+				popupDiv.innerHTML = orgTitle + popupDiv.innerHTML;
+				var formData = {
+					lat : latlng[0],
+					lng : latlng[1],
+					name : nameInput.value
+				};
+				$.post(OC.generateUrl('/apps/maps/api/1.0/favorite/addToFavorites'), formData);
+			}
+			nameDiv.appendChild(nameInput);
+			nameDiv.appendChild(submit);
+			popupDiv.insertBefore(nameDiv, popupDiv.firstChild);
 		},
 		show : function(){
 			$.post(OC.generateUrl('/apps/maps/api/1.0/favorite/getFavorites'), null, function(data){


### PR DESCRIPTION
After clicking on "add to favorites" a prompt pops up so that the user can enter a name for this favorite marker.
In a later PR this could be extended to only prompt if it is not a POI or contact (for POI or contact the app should use the POI's/contact's name as name).

Another part of #9 
What do you think? @jancborchardt @Henni @DJaeger 