### PR TITLE
show favorites on startup, save visibility setting, give feedback, fix #100

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -286,11 +286,32 @@ Array.prototype.unique = function() {
 		}, function() {
 			//TODO
 		});
-		$('.favoriteLayer').clickToggle(function() {
-			favorites.show();
-		}, function() {
-			favorites.hide();
+
+		/* Favorites layer: Show by default, remember visibility */
+		$('.favoriteLayer').click(function() {
+			if($.jStorage.get('favorites')) {
+				favorites.hide();
+				$.jStorage.set('favorites', false);
+				$('#favoriteMenu').removeClass('active').addClass('icon-star').removeClass('icon-starred');
+			} else {
+				favorites.show();
+				$.jStorage.set('favorites', true);
+				$('#favoriteMenu').addClass('active').addClass('icon-starred').removeClass('icon-star');
+			}
 		});
+		if($.jStorage.get('favorites') === null) {
+			favorites.show();
+			$.jStorage.set('favorites', true);
+			$('#favoriteMenu').addClass('active').addClass('icon-starred').removeClass('icon-star');
+		}
+		if($.jStorage.get('favorites')) {
+			favorites.show();
+			$('#favoriteMenu').addClass('active').addClass('icon-starred').removeClass('icon-star');
+		} else {
+			favorites.hide();
+		}
+
+
 		$('.contactLayer').clickToggle(function() {
 			Maps.loadAdressBooks()
 		}, function() {


### PR DESCRIPTION
Sorry for the crappy Javascript. ;D

Anyway, this shows favorites on startup by default for any new installation. Unless you disabled the layer some time before – and that setting is remembered. Also give feedback via `active` class in the navigation on if the entry is enabled. Fix #100

Please review @v1r0x @Henni 