### PR TITLE
update mapzen key if it already exists

### DIFF
--- a/controller/apikeycontroller.php
+++ b/controller/apikeycontroller.php
@@ -64,8 +64,14 @@ class ApiKeyController extends ApiController {
 		$apikey->setApiKey($key);
 		$apikey->setUserId($this->userId);
 
-		/* @var $apikey ApiKey */
-		$apikey = $this->apiKeyMapper->insert($apikey);
+        //if there is an existing key, update, insert otherwise
+        try {
+            $oldKey = $this->apiKeyMapper->findByUser($this->userId);
+            $this->updateKey($key, $oldKey->getId());
+        } catch(\OCP\AppFramework\Db\DoesNotExistException $e) {
+            /* @var $apikey ApiKey */
+            $apikey = $this->apiKeyMapper->insert($apikey);
+        }
 
 		$response = array('id'=> $apikey->getId());
 		return new JSONResponse($response);


### PR DESCRIPTION
fix #134 
@e-alfred and @GetMike could you please review?

for the record: This doesn't fix multiple entries in the table, but prevents to insert more than one entry per user. So you have to delete all keys from your user (`DELETE FROM oc_maps_apikeys WHERE user_id='yourUserId';`) by hand. Afterwards this error shouldn't occur.